### PR TITLE
💄 add feed layout

### DIFF
--- a/lib/model/guess_model.dart
+++ b/lib/model/guess_model.dart
@@ -1,0 +1,21 @@
+class Guess {
+  String? teamName;
+  String? championshipName;
+  int? ctCoins;
+
+  Guess({this.teamName, this.championshipName, this.ctCoins});
+
+  Guess.fromJson(Map<String, dynamic> json) {
+    teamName = json['teamName'];
+    championshipName = json['championshipName'];
+    ctCoins = json['CTCoins'];
+  }
+
+  Map<String, dynamic> toJson() {
+    final Map<String, dynamic> data = <String, dynamic>{};
+    data['teamName'] = teamName;
+    data['championshipName'] = championshipName;
+    data['CTCoins'] = ctCoins;
+    return data;
+  }
+}

--- a/lib/utils/verify_jwt.dart
+++ b/lib/utils/verify_jwt.dart
@@ -1,7 +1,7 @@
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 
 Future<String> verifyJwt() async {
-  final storage = FlutterSecureStorage();
+  const storage = FlutterSecureStorage();
   var jwt = await storage.read(key: "jwt");
   if (jwt == null) return "";
   return jwt;

--- a/lib/view/view_feed.dart
+++ b/lib/view/view_feed.dart
@@ -81,6 +81,249 @@ class ViewFeed extends StatelessWidget {
                     ),
                   ),
                 ),
+              ),
+              const SizedBox(height: 20),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  const Text("Suas Equipes",
+                      style: TextStyle(
+                        fontSize: 30,
+                        fontWeight: FontWeight.bold,
+                        color: AppColor.textColor,
+                      )),
+                  ElevatedButton(
+                      onPressed: () {},
+                      style: ElevatedButton.styleFrom(
+                        padding: const EdgeInsets.fromLTRB(10, 5, 10, 5),
+                        minimumSize: Size.zero,
+                        shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(5)),
+                        backgroundColor: AppColor.secondAccentColor,
+                      ),
+                      child: const Text(
+                        "VER MAIS",
+                        style: TextStyle(
+                            color: Colors.black, fontWeight: FontWeight.bold),
+                      ))
+                ],
+              ),
+              const SizedBox(height: 20),
+              SizedBox(
+                height: 90,
+                child: ListView(
+                  scrollDirection: Axis.horizontal,
+                  children: <Widget>[
+                    _buildTeamCard(
+                        teamName: "Equipe Foguete",
+                        wins: 3,
+                        playerCount: 5,
+                        imagePath:
+                            "https://picsum.photos/seed/foguete/200/200"),
+                    _buildTeamCard(
+                        teamName: "Equipe Invejosos",
+                        wins: 2,
+                        playerCount: 3,
+                        imagePath:
+                            "https://picsum.photos/seed/invejosos/200/200"),
+                    _buildTeamCard(
+                        teamName: "Alvejante Plays",
+                        wins: 3,
+                        playerCount: 5,
+                        imagePath:
+                            "https://picsum.photos/seed/alvejante/200/200"),
+                  ],
+                ),
+              ),
+              const SizedBox(height: 20),
+              const Text("Seus Torneios",
+                  style: TextStyle(
+                    fontSize: 30,
+                    fontWeight: FontWeight.bold,
+                    color: AppColor.textColor,
+                  )),
+              const SizedBox(height: 20),
+              _buildTournamentTable(),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildTournamentTable() {
+    return Table(
+      columnWidths: const {
+        0: FlexColumnWidth(1),
+        1: FlexColumnWidth(2),
+        2: FlexColumnWidth(1),
+      },
+      children: [
+        TableRow(children: [
+          TableCell(
+            child: Container(
+              padding: const EdgeInsets.all(3.0),
+              color: AppColor.primaryColor,
+              alignment: Alignment.center,
+              child: const Text(
+                'TIPO',
+                style: TextStyle(
+                  color: AppColor.textColor,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+            ),
+          ),
+          TableCell(
+            child: Container(
+              padding: const EdgeInsets.all(3.0),
+              color: AppColor.primaryColor,
+              alignment: Alignment.center,
+              child: const Text(
+                'NOME DO TORNEIO',
+                style: TextStyle(
+                  color: AppColor.textColor,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+            ),
+          ),
+          TableCell(
+            child: Container(
+              padding: const EdgeInsets.all(3.0),
+              color: AppColor.primaryColor,
+              alignment: Alignment.center,
+              child: const Text(
+                'STATUS',
+                style: TextStyle(
+                  color: AppColor.textColor,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+            ),
+          ),
+        ]),
+        TableRow(children: [
+          TableCell(child: 
+            Container(
+              padding: const EdgeInsets.all(3.0),
+              color: AppColor.backgroundColor,
+              alignment: Alignment.center,
+              child: const Icon(
+                Icons.monitor,
+                color: AppColor.textColor,
+              ),
+            )
+          ),
+          TableCell(child: 
+            Container(
+              padding: const EdgeInsets.all(3.0),
+              color: AppColor.backgroundColor,
+              alignment: Alignment.center,
+              child: const Text(
+                'Sword Fighters',
+                style: TextStyle(
+                  color: AppColor.textColor,
+                ),
+              ),
+            )
+          ),
+          TableCell(child: 
+            Container(
+              padding: const EdgeInsets.all(3.0),
+              color: AppColor.backgroundColor,
+              alignment: Alignment.center,
+              child: const Text(
+                'ATIVO',
+                style: TextStyle(
+                  color: AppColor.secondAccentColor,
+                ),
+              ),
+            )
+          ),
+        ]),
+        TableRow(children: [
+          TableCell(child: 
+            Container(
+              padding: const EdgeInsets.all(3.0),
+              color: AppColor.tertiaryColor,
+              alignment: Alignment.center,
+              child: const Icon(
+                Icons.directions_run,
+                color: AppColor.textColor,
+              ),
+            )
+          ),
+          TableCell(child: 
+            Container(
+              padding: const EdgeInsets.all(3.0),
+              color: AppColor.tertiaryColor,
+              alignment: Alignment.center,
+              child: const Text(
+                'Campeões de Maringá',
+                style: TextStyle(
+                  color: AppColor.textColor,
+                ),
+              ),
+            )
+          ),
+          TableCell(child: 
+            Container(
+              padding: const EdgeInsets.all(3.0),
+              color: AppColor.tertiaryColor,
+              alignment: Alignment.center,
+              child: const Text(
+                'INATIVO',
+                style: TextStyle(
+                  color: AppColor.secondAccentColor,
+                ),
+              ),
+            )
+          ),
+        ]),
+      ],
+    );
+  }
+
+  Widget _buildTeamCard(
+      {required String teamName,
+      int wins = 0,
+      int playerCount = 0,
+      required String imagePath}) {
+    return Card(
+      color: AppColor.primaryColor,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 10),
+        child: SizedBox(
+          width: 180,
+          child: Row(
+            children: [
+              CircleAvatar(
+                radius: 25,
+                backgroundColor: AppColor.tertiaryColor,
+                backgroundImage: NetworkImage(imagePath),
+              ),
+              const SizedBox(width: 10),
+              Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  RichText(
+                    text: TextSpan(
+                        text: teamName,
+                        style: const TextStyle(
+                            color: AppColor.secondAccentColor,
+                            fontWeight: FontWeight.bold)),
+                    textAlign: TextAlign.center,
+                  ),
+                  const SizedBox(height: 5),
+                  Text("Vitórias: $wins",
+                      style: const TextStyle(
+                          color: AppColor.textColor, fontSize: 12)),
+                  Text("Jogadores: $playerCount",
+                      style: const TextStyle(
+                          color: AppColor.textColor, fontSize: 12)),
+                ],
               )
             ],
           ),

--- a/lib/view/view_feed.dart
+++ b/lib/view/view_feed.dart
@@ -40,7 +40,7 @@ class ViewFeed extends StatelessWidget {
                   borderRadius: BorderRadius.circular(20),
                 ),
                 child: Padding(
-                  padding: const EdgeInsets.all(10.0),
+                  padding: const EdgeInsets.all(20.0),
                   child: SizedBox(
                     height: 160,
                     child: ListView(
@@ -51,27 +51,21 @@ class ViewFeed extends StatelessWidget {
                             championshipName: "Sword Fighters",
                             coins: 20),
                         const Divider(
-                          color: AppColor.accentColor,
-                          indent: 20,
-                          endIndent: 20,
+                          color: AppColor.accentColor
                         ),
                         _buildGuessRow(
                             teamName: "Death Lock",
                             championshipName: "Jogo da Velha",
                             coins: 15),
                         const Divider(
-                          color: AppColor.accentColor,
-                          indent: 20,
-                          endIndent: 20,
+                          color: AppColor.accentColor
                         ),
                         _buildGuessRow(
                             teamName: "Equipe Foguete",
                             championshipName: "Bolinha de Gude Ultimate",
                             coins: 7),
                         const Divider(
-                          color: AppColor.accentColor,
-                          indent: 20,
-                          endIndent: 20,
+                          color: AppColor.accentColor
                         ),
                         _buildGuessRow(
                             teamName: "Destroyers2000",
@@ -163,7 +157,7 @@ class ViewFeed extends StatelessWidget {
           TableCell(
             child: Container(
               padding: const EdgeInsets.all(3.0),
-              color: AppColor.primaryColor,
+              color: const Color.fromARGB(178, 46, 56, 86),
               alignment: Alignment.center,
               child: const Text(
                 'TIPO',
@@ -177,7 +171,7 @@ class ViewFeed extends StatelessWidget {
           TableCell(
             child: Container(
               padding: const EdgeInsets.all(3.0),
-              color: AppColor.primaryColor,
+              color: const Color.fromARGB(178, 46, 56, 86),
               alignment: Alignment.center,
               child: const Text(
                 'NOME DO TORNEIO',
@@ -191,7 +185,7 @@ class ViewFeed extends StatelessWidget {
           TableCell(
             child: Container(
               padding: const EdgeInsets.all(3.0),
-              color: AppColor.primaryColor,
+              color: const Color.fromARGB(178, 46, 56, 86),
               alignment: Alignment.center,
               child: const Text(
                 'STATUS',
@@ -212,6 +206,7 @@ class ViewFeed extends StatelessWidget {
               child: const Icon(
                 Icons.monitor,
                 color: AppColor.textColor,
+                size: 20,
               ),
             )
           ),
@@ -251,6 +246,7 @@ class ViewFeed extends StatelessWidget {
               child: const Icon(
                 Icons.directions_run,
                 color: AppColor.textColor,
+                size: 20,
               ),
             )
           ),
@@ -291,7 +287,7 @@ class ViewFeed extends StatelessWidget {
       int playerCount = 0,
       required String imagePath}) {
     return Card(
-      color: AppColor.primaryColor,
+      color: const Color.fromARGB(178, 46, 56, 86),
       child: Padding(
         padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 10),
         child: SizedBox(

--- a/lib/view/view_feed.dart
+++ b/lib/view/view_feed.dart
@@ -5,6 +5,8 @@ import 'package:ctracker/widget/tracker_drawer.dart';
 import 'package:flutter/material.dart';
 
 class ViewFeed extends StatelessWidget {
+  const ViewFeed({super.key});
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -18,7 +20,127 @@ class ViewFeed extends StatelessWidget {
           backgroundColor: AppColor.secondAccentColor,
           child: const Icon(Icons.search)),
       floatingActionButtonLocation: FloatingActionButtonLocation.centerDocked,
-      body: const Text("Feed"),
+      body: SingleChildScrollView(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 30),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.start,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              const Text("Seus Palpites",
+                  style: TextStyle(
+                    fontSize: 30,
+                    fontWeight: FontWeight.bold,
+                    color: AppColor.textColor,
+                  )),
+              const SizedBox(height: 20),
+              Container(
+                decoration: BoxDecoration(
+                  color: AppColor.tertiaryColor,
+                  borderRadius: BorderRadius.circular(20),
+                ),
+                child: Padding(
+                  padding: const EdgeInsets.all(10.0),
+                  child: SizedBox(
+                    height: 160,
+                    child: ListView(
+                      shrinkWrap: true,
+                      children: <Widget>[
+                        _buildGuessRow(
+                            teamName: "Blue Tigers",
+                            championshipName: "Sword Fighters",
+                            coins: 20),
+                        const Divider(
+                          color: AppColor.accentColor,
+                          indent: 20,
+                          endIndent: 20,
+                        ),
+                        _buildGuessRow(
+                            teamName: "Death Lock",
+                            championshipName: "Jogo da Velha",
+                            coins: 15),
+                        const Divider(
+                          color: AppColor.accentColor,
+                          indent: 20,
+                          endIndent: 20,
+                        ),
+                        _buildGuessRow(
+                            teamName: "Equipe Foguete",
+                            championshipName: "Bolinha de Gude Ultimate",
+                            coins: 7),
+                        const Divider(
+                          color: AppColor.accentColor,
+                          indent: 20,
+                          endIndent: 20,
+                        ),
+                        _buildGuessRow(
+                            teamName: "Destroyers2000",
+                            championshipName: "Worms W.M.D. Championship",
+                            coins: 15),
+                      ],
+                    ),
+                  ),
+                ),
+              )
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildGuessRow(
+      {required String teamName,
+      required String championshipName,
+      int coins = 0}) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 5),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: <Widget>[
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: <Widget>[
+              Container(
+                height: 8,
+                width: 8,
+                decoration: BoxDecoration(
+                  border: Border.all(color: AppColor.accentColor),
+                  borderRadius: BorderRadius.circular(2),
+                ),
+              ),
+              const SizedBox(width: 10),
+              Column(
+                mainAxisAlignment: MainAxisAlignment.start,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: <Widget>[
+                  Text(teamName,
+                      style: const TextStyle(
+                          color: AppColor.secondaryColor,
+                          fontWeight: FontWeight.bold,
+                          fontSize: 12)),
+                  Text(championshipName,
+                      style: const TextStyle(
+                          color: AppColor.textColor, fontSize: 12))
+                ],
+              ),
+            ],
+          ),
+          RichText(
+              text: TextSpan(
+            text: '$coins ',
+            children: const <TextSpan>[
+              TextSpan(
+                  text: "CTCoins",
+                  style: TextStyle(
+                      color: AppColor.secondaryColor,
+                      fontWeight: FontWeight.normal))
+            ],
+            style: const TextStyle(
+                color: AppColor.secondAccentColor, fontWeight: FontWeight.bold),
+          )),
+        ],
+      ),
     );
   }
 }

--- a/lib/view/view_home.dart
+++ b/lib/view/view_home.dart
@@ -38,17 +38,19 @@ class ViewHome extends StatelessWidget {
                     ),
                   ),
                   ElevatedButton(
-                    onPressed: () {
-                      // ação para o botão "Ver mais"
-                    },
-                    style: ElevatedButton.styleFrom(
-                      backgroundColor: AppColor.secondAccentColor,
-                      textStyle: const TextStyle(
-                          color: AppColor.textColor,
-                          fontWeight: FontWeight.bold),
-                    ),
-                    child: const Text('Ver mais'),
-                  ),
+                      onPressed: () {},
+                      style: ElevatedButton.styleFrom(
+                        padding: const EdgeInsets.fromLTRB(10, 5, 10, 5),
+                        minimumSize: Size.zero,
+                        shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(5)),
+                        backgroundColor: AppColor.secondAccentColor,
+                      ),
+                      child: const Text(
+                        "VER MAIS",
+                        style: TextStyle(
+                            color: Colors.black, fontWeight: FontWeight.bold),
+                      ))
                 ],
               ),
             ),

--- a/lib/view/view_shop.dart
+++ b/lib/view/view_shop.dart
@@ -5,6 +5,8 @@ import 'package:ctracker/widget/tracker_drawer.dart';
 import 'package:flutter/material.dart';
 
 class ViewShop extends StatelessWidget {
+  const ViewShop({super.key});
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(

--- a/lib/widget/bottom_navigation.dart
+++ b/lib/widget/bottom_navigation.dart
@@ -58,7 +58,7 @@ class _BottomNavigation extends State<BottomNavigation> {
               size: 30,
             ),
             onPressed: () {
-              Navigator.pushReplacement(context, MaterialPageRoute(builder: (context) => ViewFeed()));
+              Navigator.pushReplacement(context, MaterialPageRoute(builder: (context) => const ViewFeed()));
             },
           ),
           IconButton(
@@ -68,7 +68,7 @@ class _BottomNavigation extends State<BottomNavigation> {
               size: 30,
             ),
             onPressed: () {
-              Navigator.pushReplacement(context, MaterialPageRoute(builder: (context) => ViewShop()));
+              Navigator.pushReplacement(context, MaterialPageRoute(builder: (context) => const ViewShop()));
             },
           ),
         ],

--- a/lib/widget/chip_button.dart
+++ b/lib/widget/chip_button.dart
@@ -18,7 +18,7 @@ class _ChipButton extends State<ChipButton>{
   Widget build(BuildContext context){
     return FilterChip(
       label: Text(widget.labelText),
-        labelStyle: TextStyle(color: AppColor.textColor, fontSize: 14.0, fontWeight: FontWeight.bold),
+        labelStyle: const TextStyle(color: AppColor.textColor, fontSize: 14.0, fontWeight: FontWeight.bold),
       selected: _isSelected,
         shape: RoundedRectangleBorder(
           borderRadius: BorderRadius.circular(30.0),

--- a/lib/widget/oauth.dart
+++ b/lib/widget/oauth.dart
@@ -6,11 +6,11 @@ class OAuth extends StatelessWidget {
   final Color containerColor;
   
   const OAuth({
-    Key? key,
+    super.key,
     required this.imagePath,
     this.borderColor = Colors.white,
     this.containerColor = Colors.white,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.0.0+1
+version: 0.1.0-alpha
 
 environment:
   sdk: '>=3.3.3 <4.0.0'


### PR DESCRIPTION
Este PR cria a interface da tela Feed Pessoal, que contém uma lista de palpites realizados, lista das equipes e torneios favoritos.

Além da criação da interface, eu também tomei a liberdade de editar a versão do aplicativo no pubspec e rodar o comando `dart fix` para arrumar problemas de boas práticas e sintaxe que o dart identificar. 

A última música da minha playlist que ouvi quando terminei o código foi [Mass Destruction -Reload-](https://www.youtube.com/watch?v=Q6q6pDC6Mas)